### PR TITLE
Update notebooks: adjust outputs, configs, metadata

### DIFF
--- a/4LLM_Evaluation_and_Security/1NLP_Evaluators_Case_Study.ipynb
+++ b/4LLM_Evaluation_and_Security/1NLP_Evaluators_Case_Study.ipynb
@@ -34,24 +34,7 @@
    "outputs": [],
    "source": [
     "# Install the packages\n",
-    "#%pip install azure-ai-evaluation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "parameters"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "azure_ai_project = {\n",
-    "    \"subscription_id\": \"YOUR-SUBSCRIPTION-ID\",#<YOUR-SUBSCRIPTION-ID>\n",
-    "    \"resource_group_name\": \"YOUR-AZURE-RESOURCE-GROU\",# khipus-ai-gpt\n",
-    "    \"project_name\": \"YOUR-PROJECT-NAME\",# khipus-ai-gpt2025\n",
-    "}"
+    "# %pip install azure-ai-evaluation"
    ]
   },
   {
@@ -77,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -107,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -142,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -185,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,14 +179,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'meteor_score': 0.9067055393586005, 'meteor_result': 'fail', 'meteor_threshold': 0.5}\n"
+      "{'meteor_score': 0.9067055393586005, 'meteor_result': 'pass', 'meteor_threshold': 0.5}\n"
      ]
     }
    ],
@@ -228,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -259,7 +242,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": ".venv2",
    "language": "python",
    "name": "python3"
   },
@@ -273,7 +256,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,

--- a/4LLM_Evaluation_and_Security/2llm_evaluation_Assignment5.ipynb
+++ b/4LLM_Evaluation_and_Security/2llm_evaluation_Assignment5.ipynb
@@ -43,7 +43,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 6,
             "metadata": {},
             "outputs": [],
             "source": [
@@ -59,17 +59,9 @@
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 7,
             "metadata": {},
-            "outputs": [
-                {
-                    "name": "stdout",
-                    "output_type": "stream",
-                    "text": [
-                        "[INFO] Could not import AIAgentConverter. Please install the dependency with `pip install azure-ai-projects`.\n"
-                    ]
-                }
-            ],
+            "outputs": [],
             "source": [
                 "\n",
                 "import json\n",
@@ -98,9 +90,9 @@
             "source": [
                 "\n",
                 "model_config = AzureOpenAIModelConfiguration(\n",
-                "    azure_endpoint=\"replace with your endpoint\",# https://azure-openai-<your-resource-name>.openai.azure.com/\n",
-                "    api_key=\"replace with your key\",# key from the Azure OpenAI resource\n",
-                "    azure_deployment=\"gpt-4.1-mini\",\n",
+                "    azure_endpoint=\"YOUR_AZURE_OPENAI_ENDPOINT\", # endpoint from the Azure OpenAI resource\n",
+                "    api_key=\"YOUR_AZURE_OPENAI_API_KEY\",# API key from the Azure OpenAI resource\n",
+                "    azure_deployment=\"gpt-4o\", # deployment name from the Azure OpenAI resource (USE THE DEPLOYMENT NAME THAT YOU CHOOSE FROM THE COURSE)\n",
                 "    api_version=\"2023-05-15\"  \n",
                 ")\n"
             ]
@@ -117,7 +109,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 4,
+            "execution_count": 9,
             "metadata": {
                 "id": "5",
                 "language": "python"
@@ -127,7 +119,7 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Coherence Score: {'coherence': 4.0, 'gpt_coherence': 4.0, 'coherence_reason': 'The response directly and clearly answers the question with a complete sentence, showing logical and orderly presentation of the idea. It is easy to follow and fully coherent.', 'coherence_result': 'pass', 'coherence_threshold': 3}\n"
+                        "Coherence Score: {'coherence': 5.0, 'gpt_coherence': 5.0, 'coherence_reason': 'The RESPONSE is coherent, logically structured, and directly answers the QUERY without any issues in flow or organization.', 'coherence_result': 'pass', 'coherence_threshold': 3, 'coherence_prompt_tokens': 1264, 'coherence_completion_tokens': 117, 'coherence_total_tokens': 1381, 'coherence_finish_reason': 'stop', 'coherence_model': 'gpt-4o-2024-11-20', 'coherence_sample_input': '[{\"role\": \"user\", \"content\": \"{\\\\\"query\\\\\": \\\\\"What is the capital of France?\\\\\", \\\\\"response\\\\\": \\\\\"The capital of France is Paris.\\\\\"}\"}]', 'coherence_sample_output': '[{\"role\": \"assistant\", \"content\": \"<S0>Let\\'s think step by step: The QUERY asks for the capital of France, and the RESPONSE directly answers the question by stating \\\\\"The capital of France is Paris.\\\\\" The information is accurate, concise, and logically presented. There is no ambiguity or disjointedness in the response, and the sentence flows smoothly. The RESPONSE fully addresses the QUERY with clarity and precision.</S0>  \\\\n<S1>The RESPONSE is coherent, logically structured, and directly answers the QUERY without any issues in flow or organization.</S1>  \\\\n<S2>5</S2>  \"}]'}\n"
                     ]
                 }
             ],
@@ -155,7 +147,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 5,
+            "execution_count": 10,
             "metadata": {
                 "id": "7",
                 "language": "python"
@@ -165,7 +157,7 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Fluency Score: {'fluency': 3.0, 'gpt_fluency': 3.0, 'fluency_reason': 'The response is clear and grammatically correct but simple and lacks complexity or varied vocabulary, fitting the definition of competent fluency.', 'fluency_result': 'pass', 'fluency_threshold': 3}\n"
+                        "Fluency Score: {'fluency': 3.0, 'gpt_fluency': 3.0, 'fluency_reason': 'The response is clear and error-free but uses basic vocabulary and simple sentence construction, which aligns with Competent Fluency.', 'fluency_result': 'pass', 'fluency_threshold': 3, 'fluency_prompt_tokens': 926, 'fluency_completion_tokens': 120, 'fluency_total_tokens': 1046, 'fluency_finish_reason': 'stop', 'fluency_model': 'gpt-4o-2024-11-20', 'fluency_sample_input': '[{\"role\": \"user\", \"content\": \"{\\\\\"response\\\\\": \\\\\"To make a cake, you need flour, sugar, and eggs.\\\\\"}\"}]', 'fluency_sample_output': '[{\"role\": \"assistant\", \"content\": \"<S0>Let\\'s think step by step: The response is grammatically correct and conveys a clear idea. The vocabulary is basic and limited, and the sentence structure is simple without any complexity or variety. There are no errors, and the message is easily understood. However, the response lacks sophistication, varied vocabulary, and complex sentence structures that would elevate it to higher fluency levels.</S0>  \\\\n<S1>The response is clear and error-free but uses basic vocabulary and simple sentence construction, which aligns with Competent Fluency.</S1>  \\\\n<S2>3</S2>  \"}]'}\n"
                     ]
                 }
             ],
@@ -193,15 +185,15 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 6,
+            "execution_count": 11,
             "metadata": {},
             "outputs": [
                 {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Groundedness Score: 3.0\n",
-                        "Explanation: The response attempts to answer the query by listing planets but incorrectly includes Pluto as a planet and omits Neptune, which is inaccurate based on the context. Hence, it contains incorrect information and is not fully grounded.\n"
+                        "Groundedness Score: 2.0\n",
+                        "Explanation: The response attempts to answer the query but includes incorrect information by listing Pluto as a planet, which is not supported by the context. This makes the response unreliable.\n"
                     ]
                 }
             ],
@@ -232,7 +224,7 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 7,
+            "execution_count": 12,
             "metadata": {
                 "id": "11",
                 "language": "python"
@@ -242,7 +234,7 @@
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Relevance Score: {'relevance': 4.0, 'gpt_relevance': 4.0, 'relevance_reason': 'The response correctly and completely answers the question by identifying the cheetah as the fastest land animal, fulfilling the requirement for a complete and accurate answer.', 'relevance_result': 'pass', 'relevance_threshold': 3}\n"
+                        "Relevance Score: {'relevance': 4.0, 'gpt_relevance': 4.0, 'relevance_result': 'pass', 'relevance_threshold': 3, 'relevance_reason': \"The response directly and accurately answers the user's query by identifying the cheetah as the fastest land animal. It is fully relevant and sufficient for the question asked.\", 'relevance_prompt_tokens': 1589, 'relevance_completion_tokens': 48, 'relevance_total_tokens': 1637, 'relevance_finish_reason': 'stop', 'relevance_model': 'gpt-4o-2024-11-20', 'relevance_sample_input': '[{\"role\": \"user\", \"content\": \"{\\\\\"query\\\\\": \\\\\"What is the fastest land animal?\\\\\", \\\\\"response\\\\\": \\\\\"The cheetah is the fastest land animal.\\\\\"}\"}]', 'relevance_sample_output': '[{\"role\": \"assistant\", \"content\": \"{\\\\n  \\\\\"explanation\\\\\": \\\\\"The response directly and accurately answers the user\\'s query by identifying the cheetah as the fastest land animal. It is fully relevant and sufficient for the question asked.\\\\\",\\\\n  \\\\\"score\\\\\": 4\\\\n}\"}]'}\n"
                     ]
                 }
             ],
@@ -270,14 +262,14 @@
         },
         {
             "cell_type": "code",
-            "execution_count": 8,
+            "execution_count": 13,
             "metadata": {},
             "outputs": [
                 {
                     "name": "stdout",
                     "output_type": "stream",
                     "text": [
-                        "Retrieval score: {'retrieval': 5.0, 'gpt_retrieval': 5.0, 'retrieval_reason': 'The context directly and succinctly answers the query with the most relevant information at the top, making it highly relevant and well ranked without any bias.', 'retrieval_result': 'pass', 'retrieval_threshold': 3}\n"
+                        "Retrieval score: {'retrieval': 5.0, 'gpt_retrieval': 5.0, 'retrieval_reason': 'The context fully addresses the query with the most relevant information ranked at the top, meeting the criteria for a perfect retrieval score.', 'retrieval_result': 'pass', 'retrieval_threshold': 3, 'retrieval_prompt_tokens': 3479, 'retrieval_completion_tokens': 121, 'retrieval_total_tokens': 3600, 'retrieval_finish_reason': 'stop', 'retrieval_model': 'gpt-4o-2024-11-20', 'retrieval_sample_input': '[{\"role\": \"user\", \"content\": \"{\\\\\"query\\\\\": \\\\\"What is the largest ocean on Earth?\\\\\", \\\\\"context\\\\\": \\\\\"The Pacific Ocean covers about 165 million km\\\\\\\\u00b2, making it the largest.\\\\\"}\"}]', 'retrieval_sample_output': '[{\"role\": \"assistant\", \"content\": \"<S0>Let\\'s think step by step: The query asks for the largest ocean on Earth. The context directly provides the answer, stating that the Pacific Ocean is the largest and includes its size. The information is highly relevant to the query, and the most pertinent chunk is surfaced at the top. There is no external knowledge bias, and the retrieval focuses solely on the provided context.</S0>  \\\\n<S1>The context fully addresses the query with the most relevant information ranked at the top, meeting the criteria for a perfect retrieval score.</S1>  \\\\n<S2>5</S2>  \"}]'}\n"
                     ]
                 }
             ],
@@ -306,9 +298,18 @@
         },
         {
             "cell_type": "code",
-            "execution_count": null,
+            "execution_count": 14,
             "metadata": {},
-            "outputs": [],
+            "outputs": [
+                {
+                    "name": "stdout",
+                    "output_type": "stream",
+                    "text": [
+                        "Groundedness Score: 2.0\n",
+                        "Explanation: The RESPONSE contains incorrect information about the date of the moon landing, which makes it unreliable and not grounded in the CONTEXT.\n"
+                    ]
+                }
+            ],
             "source": [
                 "# Your code here\n",
                 "# Create a groundedness evaluator\n",
@@ -338,7 +339,7 @@
     ],
     "metadata": {
         "kernelspec": {
-            "display_name": ".venv",
+            "display_name": ".venv2",
             "language": "python",
             "name": "python3"
         },
@@ -352,7 +353,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.11.9"
+            "version": "3.13.5"
         }
     },
     "nbformat": 4,


### PR DESCRIPTION
Apply minor edits to two evaluation notebooks: normalize execution counts, update commented pip install line, and bump kernelspec display name and Python version. In 1NLP_Evaluators_Case_Study.ipynb remove the hardcoded azure_ai_project parameter block, change the meteor result to 'pass', and adjust execution counts. In 2llm_evaluation_Assignment5.ipynb update AzureOpenAIModelConfiguration placeholders, remove an import warning output, add and standardize evaluator outputs (more detailed explanations, token/model metadata, and some score changes), add a groundedness stdout block, and adjust execution counts. These changes mainly clean up examples, clarify config placeholders, and reflect updated evaluator outputs/metadata.